### PR TITLE
Fix reset initialized flag

### DIFF
--- a/zsrtp/include/crypto/skein_port.h
+++ b/zsrtp/include/crypto/skein_port.h
@@ -17,7 +17,10 @@
 
 #include <crypto/brg_types.h>                      /* get integer type definitions */
 
+//r3gis3r : android already has that defined in types
+#ifndef ANDROID
 typedef unsigned int    uint_t;             /* native unsigned integer */
+#endif
 typedef uint_8t         u08b_t;             /*  8-bit unsigned integer */
 typedef uint_64t        u64b_t;             /* 64-bit unsigned integer */
 

--- a/zsrtp/zrtp/ZIDFile.cpp
+++ b/zsrtp/zrtp/ZIDFile.cpp
@@ -23,6 +23,9 @@
 #include <string>
 #include <time.h>
 #include <stdlib.h>
+#ifdef ANDROID
+#include <unistd.h>
+#endif
 
 #include <libzrtpcpp/ZIDFile.h>
 

--- a/zsrtp/zrtp/ZrtpCWrapper.cpp
+++ b/zsrtp/zrtp/ZrtpCWrapper.cpp
@@ -77,6 +77,8 @@ void zrtp_DestroyWrapper(ZrtpContext* zrtpContext) {
     zrtpContext->configure = NULL;
     
     delete zrtpContext;
+
+    initialized = 0;
 }
 
 static int32_t zrtp_initZidFile(const char* zidFilename) {


### PR DESCRIPTION
A little contribution : I noticed that when I tried to make to consecutive calls, the second one crashed. 
After reviewing of the code I noticed that the initialized flag was not reset when zrtp transport was destroyed. Fixing that fixed the crash, but since I didn't dive deeper in the code it may be wrong :). Just let me know ;)

I also added some little changes to be able to build on android (all enclosed into #ifdef ANDROID, cause I guess only a problem with android toolchain).
