### PR TITLE
Makefile fix

### DIFF
--- a/build/zsrtp/Makefile
+++ b/build/zsrtp/Makefile
@@ -1,6 +1,6 @@
 # Adapt this path to your pjproject path
 
-export PJDIR := ~/devhome/pjproject.git
+export PJDIR := ~/xPhoneProject/pjproject
 
 include $(PJDIR)/build.mak
 include $(PJDIR)/build/common.mak
@@ -20,6 +20,7 @@ export _CFLAGS 	:= $(CC_INC). $(CC_INC)../../zsrtp/include \
 		   $(CC_INC)../../zsrtp/zrtp/zrtp/libzrtpcpp \
 		   $(CC_INC)../../zsrtp/zrtp/srtp \
 		   $(CC_INC)../../zsrtp/zrtp/srtp/crypto \
+		   $(CC_INC)../../zsrtp/common \
 		   $(CC_INC)$(PJDIR)/pjlib/include \
 		   $(CC_INC)$(PJDIR)/pjlib-util/include \
 		   $(CC_INC)$(PJDIR)/pjmedia/include \
@@ -73,7 +74,8 @@ zrtpobj = zrtp/zrtp/ZrtpCallbackWrapper.o \
     zrtp/zrtp/ZrtpTextData.o \
     zrtp/zrtp/ZrtpConfigure.o \
     zrtp/zrtp/ZrtpCWrapper.o \
-    zrtp/zrtp/Base32.o
+    zrtp/zrtp/Base32.o \
+    zrtp/common/osSpecifics.o
 
 srtpobj = srtp/ZsrtpCWrapper.o zrtp/srtp/CryptoContext.o zrtp/srtp/CryptoContextCtrl.o
 


### PR DESCRIPTION
Hi, Mr. Werner,

My name is Mihai (which is Romanian version for Mike)

I am currently developing a softphone which uses PJSIP and ZRTP4PJ as secured media transport.

I've compiled ZRTP4PJ successfully but after linking my project with the library, I got a linker error saying that external symbols zrtpNtohl and zrtpHtonl are undefined.
I have searched a little bit more and found that file osSpecifics.c (which implements the body of the above two functions) is not compiled into ZRTP4PJ library.

So, I'd like to bring my first contribution to ZRTP4PJ project by submitting the updated Makefile.

Best regards,

Mihai  
